### PR TITLE
search_index.jsonの生成をしない

### DIFF
--- a/src/book.json
+++ b/src/book.json
@@ -4,6 +4,7 @@
     "summary": "SUMMARY.md"
   },
   "plugins": [
+    "-search",
     "include-codeblock",
     "japanese-support",
     "footnote-string-to-number"


### PR DESCRIPTION
ページの読み込みが重い直接の原因ではないかもしれないが、
いずれにせよファイルが大きい(9MB)ので、一旦無効化

ref https://github.com/dwango/scala_text/issues/8