### PR TITLE
gitbookのバージョンを明示

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ addons:
     - gcc-4.8
     - g++-4.8
 script:
-- sbt textLintAll textTestAll textBuildHtml test &&
+- sbt textLintAll textTestAll "textBuildHtml --gitbook=2.6.7" test &&
   wget -nv -O- https://raw.githubusercontent.com/kovidgoyal/calibre/77904f0859e36d/setup/linux-installer.py
   | python -c "import sys; main=lambda x,y:sys.stderr.write('Download failed\n');
   exec(sys.stdin.read()); main('~/calibre-bin', True)" >/dev/null &&
   export PATH="~/calibre-bin/calibre/:/home/travis/calibre-bin/calibre/:$PATH" &&
-  sbt textBuildEpub
+  sbt "textBuildEpub --gitbook=2.6.7"
 after_success:
 - "./deploy.sh"
 after_script:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,6 @@ import tut.Plugin._
 object build extends Build with NpmCliBase {
   lazy val textLintAll = taskKey[Unit]("lint text, html")
   lazy val textTestAll = taskKey[Unit]("test scala, links")
-  lazy val textBuildAllWithCheck = taskKey[Unit]("lintAll testAll build")
 
   lazy val root = (project in file(".")).
     settings(
@@ -21,9 +20,7 @@ object build extends Build with NpmCliBase {
       GitBook.settings ++ TextLint.settings ++ LinkTest.settings
     ).settings(
       textLintAll := Def.sequential(LinkTest.textEslint, TextLint.textLint.toTask("")).value,
-      textTestAll := Def.sequential(compile in Test, LinkTest.textLinkTest).value,
-      // tutはビルドプロセスで自動的に実行される
-      textBuildAllWithCheck := Def.sequential(textLintAll, textTestAll, GitBook.textBuildAll).value
+      textTestAll := Def.sequential(compile in Test, LinkTest.textLinkTest).value
     ).aggregate(
       RootProject(file("src/example_projects/trait-example")),
       RootProject(file("src/example_projects/trait-refactored-example"))

--- a/project/GitBook.scala
+++ b/project/GitBook.scala
@@ -31,7 +31,6 @@ object GitBook extends NpmCliBase {
   lazy val textBuildHtml = inputKey[Unit]("build GitBook to html")
   lazy val textBuildEpub = inputKey[Unit]("build GitBook to epub")
   lazy val textBuildPdf = inputKey[Unit]("build GitBook to pdf")
-  lazy val textBuildAll = taskKey[Unit]("build GitBook to all format")
 
   val settings = Seq(
     textPluginInstall := printRun(Process(s"$gitbookBin install")),
@@ -49,9 +48,6 @@ object GitBook extends NpmCliBase {
     */
     textBuildOnly := buildBook(Format.Html).evaluated,
     textBuildEpub := buildBook(Format.Epub).dependsOn(tut).evaluated,
-    textBuildPdf := sys.error("pdf-convertで利用するcalibreがcentOS6で上手く動かないので停止中"),
-    // 全部パラレルにやっていいのか不明なので逐次実行
-    // pdfはエラーになるので実行していない
-    textBuildAll <<= textBuildEpub.toTask("") dependsOn textBuildHtml.toTask("")
+    textBuildPdf := sys.error("pdf-convertで利用するcalibreがcentOS6で上手く動かないので停止中")
   )
 }


### PR DESCRIPTION
gitbook-cliにバージョン指定機能があることに気がついたので明示するようにしました。
指定しない場合は、  gitbook-cliで初めてビルドを行った時の最新バージョンが`~/.gitbook/versions` にインストールされ、そのバージョンでビルドが行われます。

いまどのバージョンでビルドしているのか良く分からなくなったり、手元だと古いバージョンのままビルドが行われるが、travisでは毎回新しいgitbookのバージョンでビルドされる？といった環境の差異の原因にもなるので明示したほうが良さそうです。

（指定したバージョンが無かったら自動でインストールしてくれるようなので、インストール処理などは追加しなくてよさそうです。）