### PR TITLE
textlintのバージョンアップ

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "babel": "6.5.2",
-    "babel-preset-es2015": "6.5.0",
+    "babel-preset-es2015": "6.6.0",
     "cheerio": "0.20.0",
     "eslint": "2.2.0",
     "eslint-config-eslint": "3.0.0",
@@ -25,7 +25,7 @@
     "q-io": "1.13.2",
     "sleep": "3.0.1",
     "svgexport": "0.3.0",
-    "textlint": "5.3.1",
+    "textlint": "5.4.1",
     "textlint-rule-incremental-headers": "0.2.0",
     "textlint-rule-preset-japanese": "1.0.3",
     "textlint-rule-preset-jtf-style": "2.0.0",


### PR DESCRIPTION
textlint側で早速対応していただけたので、バージョンを上げます！
https://github.com/textlint/textlint/releases/tag/5.4.1

ついでにリリースされていたbabel-preset-es2015もあげています。