### PR TITLE
解答例の折りたたみを実現

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gitbook-plugin-footnote-string-to-number": "0.0.2",
     "gitbook-plugin-include-codeblock": "1.6.1",
     "gitbook-plugin-japanese-support": "0.0.1",
+    "gitbook-plugin-regexplace":"1.0.6",
     "kramed": "0.5.5",
     "mocha": "2.4.5",
     "npm-check-updates": "2.5.8",

--- a/src/book.json
+++ b/src/book.json
@@ -8,7 +8,16 @@
     "include-codeblock",
     "japanese-support",
     "footnote-string-to-number",
-    "anchors"
+    "anchors",
+    "regexplace"
   ],
+  "pluginsConfig": {
+    "regexplace": {
+      "substitutes": [
+        {"pattern": "<!-- section id=\"(.*)\" style=\"(.*)\" -->", "flags": "g", "substitute": "<div id=\"$1\" style=\"$2\">"},
+        {"pattern": "<!-- endsection -->", "flags": "g", "substitute": "</div>"}
+      ]
+    }
+  },
   "title": "Scala研修テキスト"
 }

--- a/src/book.json
+++ b/src/book.json
@@ -14,8 +14,8 @@
   "pluginsConfig": {
     "regexplace": {
       "substitutes": [
-        {"pattern": "<!-- section id=\"(.*)\" style=\"(.*)\" -->", "flags": "g", "substitute": "<div id=\"$1\" style=\"$2\">"},
-        {"pattern": "<!-- endsection -->", "flags": "g", "substitute": "</div>"}
+        {"pattern": "<!-- begin answer id=\"(.*)\" style=\"(.*)\" -->", "flags": "g", "substitute": "<div><button type=\"button\" onclick=\"document.getElementById('$1').style.display='block';\">解答例を表示する</button><button type=\"button\" onclick=\"document.getElementById('$1').style.display='none';\">解答例を隠す</button></div><div id=\"$1\" style=\"$2\">"},
+        {"pattern": "<!-- end answer -->", "flags": "g", "substitute": "</div>"}
       ]
     }
   },

--- a/src/collection.md
+++ b/src/collection.md
@@ -72,10 +72,7 @@ def swapArray[T](arr: Array[T])(i: Int, j: Int): Unit = ???
 
 となります。ヒント：`swapArray`の結果は次のようになっていなければいけません。また、`i`と`j`が配列の範囲外である場合は特に考慮しなくて良いです。
 
-<button type="button" onclick="document.getElementById('sectionex1').style.display='block';">解答例を表示する</button>
-<button type="button" onclick="document.getElementById('sectionex1').style.display='none';">解答例を隠す</button>
-
-<!-- section id="sectionex1" style="display:none" -->
+<!-- begin answer id="sectionex1" style="display:none" -->
 
 ```tut
 def swapArray[T](arr: Array[T])(i: Int, j: Int): Unit = {
@@ -97,7 +94,7 @@ swapArray(arr)(1, 3)
 arr
 ```
 
-<!-- endsection -->
+<!-- end answer -->
 
 ### [Range](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/Range.scala)（★★）
 

--- a/src/collection.md
+++ b/src/collection.md
@@ -70,9 +70,14 @@ arr.length
 def swapArray[T](arr: Array[T])(i: Int, j: Int): Unit = ???
 ```
 
-となります。ヒント：`swapArray`の結果は次のようになっていなければいけません。また、`i`と`j`が配列の範囲外である場合は特に考慮しなくて良いです。解答例は[こちら](https://github.com/dwango/scala_text/blob/master/src/collection.md#練習問題)から。
+となります。ヒント：`swapArray`の結果は次のようになっていなければいけません。また、`i`と`j`が配列の範囲外である場合は特に考慮しなくて良いです。
 
-```tut:invisible
+<button type="button" onclick="document.getElementById('sectionex1').style.display='block';">解答例を表示する</button>
+<button type="button" onclick="document.getElementById('sectionex1').style.display='none';">解答例を隠す</button>
+
+<!-- section id="sectionex1" style="display:none" -->
+
+```tut
 def swapArray[T](arr: Array[T])(i: Int, j: Int): Unit = {
   val tmp = arr(i)
   arr(i) = arr(j)
@@ -91,6 +96,8 @@ swapArray(arr)(1, 3)
 
 arr
 ```
+
+<!-- endsection -->
 
 ### [Range](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/Range.scala)（★★）
 


### PR DESCRIPTION
* [gitbook-plugin-regexplace](https://github.com/markomanninen/gitbook-plugin-regexplace) を使って実現

```
<!-- section id=".*" style=".*" -->
```
が現れたら、

```
<div id="$1" style="$2">
```
 に置き換え

```
<!-- endsection -->
```

が現れたら、

```
</div>
```

に置き換え

* 綺麗ではないが、regexplaceを使えばmarkdownをHTMLのブロック要素で簡単に囲むことができる