### PR TITLE
example_projects以下ではtextlintを実行しない

### DIFF
--- a/project/NpmCliBase.scala
+++ b/project/NpmCliBase.scala
@@ -7,7 +7,7 @@ trait NpmCliBase {
 
   // 執筆者の手により編集されるディレクトリ
   val srcDir = file("src")
-  def srcMarkdowns = srcDir.listFiles("*.md")
+  def srcMarkdowns = srcDir.listFiles("*.md").filterNot(f => f.getPath.contains("src/example_projects/"))
 
   // gitbookのビルドの起点になるディレクトリ(book/_book/index.htmlが生成される)
   val bookBuildDir = file("gitbook")

--- a/project/TextLint.scala
+++ b/project/TextLint.scala
@@ -10,7 +10,7 @@ object TextLint extends NpmCliBase {
   val settings = Seq(
     textLint := {
       val args = rawStringArg(srcMarkdowns.mkString("\n")).parsed
-      val options = if(args.isEmpty) s"$srcDir" else args
+      val options = if(args.isEmpty) srcMarkdowns.mkString("\n") else args
 
       printRun(Process(s"$textlintBin $options"))
     }


### PR DESCRIPTION
example_projects以下のreadme.mdがtextlintに引っかかってしまう問題が発生したのでlint対象から除外します。