### PR TITLE
“java”を“Java”へ変更

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -16,6 +16,6 @@
 - [型クラスの紹介](typeclass.md)
 - [FutureとPromise](future-and-promise.md)
 - [テスト](test.md)
-- [javaとの相互運用](java-interop.md)
+- [Javaとの相互運用](java-interop.md)
 - [S99の案内](exercises.md)
 - [トレイトの応用編：依存性の注入によるリファクタリング](advanced-trait-di.md)


### PR DESCRIPTION
`SUMMARY.md`では“java”となっていた表記を、記事のタイトルと同様に先頭が大文字の“Java”へ変更した。