### PR TITLE
CompletableFutureについて脚注を追加

### DIFF
--- a/src/future-and-promise.md
+++ b/src/future-and-promise.md
@@ -39,7 +39,7 @@ flatMapやfilter、for式の適用といったようなOptionやListでも利用
 このFutureは基本的で重要な役割を果たすクラスとなります。
 
 なおJavaにも[Future](http://docs.oracle.com/javase/jp/8/docs/api/java/util/concurrent/Future.html)というクラスがありますが、
-こちらには関数を与えたり、Optionの持つ特性はありません。
+こちらには関数を与えたり[^CompletableFuture]、Optionの持つ特性はありません。
 また、ECMAScript 6にある[Promise](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 という機能がありますが、そちらの方がScalaのFutureの機能に似ています。
 このECMAScript 6のPromiseとScalaのPromiseは、全く異なる機能であるため注意が必要です。
@@ -396,4 +396,5 @@ Promiseの配列のそれぞれに成功結果を定義しています。
 このRxは元々はC#で生まれたReactive Extensionsというライブラリで、
 現在では[様々な言語にポーティング](https://github.com/Reactive-Extensions)が行われています。
 
+[^CompletableFuture]: ただし、Java 8から追加されたjava.util.concurrent.Futureのサブクラスである[CompletableFuture](http://docs.oracle.com/javase/jp/8/docs/api/java/util/concurrent/CompletableFuture.html)には、関数を引数にとるメソッドがあります。
 [^concurrent]: 値の原始的な更新や同期の必要性などの並行処理に関する様々な話題の詳細な解説は本書の範囲をこえてしまうため割愛します。「Java Concurrency in Practice」ないしその和訳「Java並行処理プログラミング ー その「基盤」と「最新API」を究める」や「Effective Java」といった本でこれらの話題について学ぶことが出来ます。


### PR DESCRIPTION
たしかにjava.util.concurrent.Future自体には関数を引数に取るメソッドはないが、
そのサブクラスにそういったメソッドが存在する場合があるのは、
なんだか現状の説明では微妙に嘘ついてるというか説明不足な気がしたので、
脚注に一言くらいあってもいいかな、という気持ち