### PR TITLE
Scalaコードのコメントの書き方微修正

### DIFF
--- a/src/test.md
+++ b/src/test.md
@@ -163,31 +163,22 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 ```tut:silent
 class Calc {
 
-  /**
-   * 整数の配列を取得し、それらを出し合わせた整数を返す
-   * Intの最大を上回った際にはオーバーフローする
-   * @param seq
-   * @return
-   */
+  /** 整数の配列を取得し、それらを出し合わせた整数を返す
+    *
+    * Intの最大を上回った際にはオーバーフローする
+    */
   def sum(seq: Seq[Int]): Int = seq.foldLeft(0)(_ + _)
 
-  /**
-   * 整数を2つ受け取り、分子を分母で割った浮動小数点の値を返す
-   * 0で割ろうとした際には実行時例外が投げられる
-   * @param numerator
-   * @param denominator
-   * @return
-   */
+  /** 整数を2つ受け取り、分子を分母で割った浮動小数点の値を返す
+    *
+    * 0で割ろうとした際には実行時例外が投げられる
+    */
   def div(numerator: Int, denominator: Int): Double = {
     if (denominator == 0) throw new ArithmeticException("/ by zero")
     numerator.toDouble / denominator.toDouble
   }
 
-  /**
-   * 整数値を一つ受け取り、その値が素数であるかどうかのブール値を返す
-   * @param n
-   * @return
-   */
+  /** 整数値を一つ受け取り、その値が素数であるかどうかのブール値を返す */
   def isPrime(n: Int): Boolean = {
     if (n < 2) false else !((2 to Math.sqrt(n).toInt) exists (n % _ == 0))
   }


### PR DESCRIPTION
Scaladocの推奨スタイルは、いくつかJavaと違うので注意

http://docs.scala-lang.org/style/scaladoc.html

- `/**` の直後の1行目に書く(Javaでは書かない)
- 2行目以降の `*` の揃え方がJavadocと異なる(ただし、標準ライブラリでもこの形式になっていなかったりして、それほど守られてはいないが)

また、個人的にコメント書かないのにparamやreturnあるの無意味に感じるので削除