### PR TITLE
余分な%を除去

### DIFF
--- a/src/test.md
+++ b/src/test.md
@@ -399,7 +399,7 @@ BDDでテストを書くことによってテストによってどのような�
 `build.sbt`に以下を追記することで利用可能になります。
 
 ```tut:silent
-libraryDependencies += "org.mockito" %% "mockito-core" % "1.10.19" % "test"
+libraryDependencies += "org.mockito" % "mockito-core" % "1.10.19" % "test"
 ```
 
 せっかくなので、先ほど用意したCalcクラスのモックを用意して、モックにsumの振る舞いを仕込んで見ましょう。


### PR DESCRIPTION
Mockito のバージョン番号には _2.11 みたいな接尾辞はついていないので%%ではまずいですね
http://mvnrepository.com/artifact/org.mockito/mockito-core/1.10.19