### PR TITLE
Gitbookをv3にアップデート

### DIFF
--- a/.bookignore
+++ b/.bookignore
@@ -1,0 +1,2 @@
+# gitbookディレクトリが無視されているとSUMMARY.md等が読み込まれないので除外から外す
+!/gitbook

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .DS_Store
 
 ### gitbook ###
-gitbook
+/gitbook
 
 ### npm ###
 node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ addons:
     - gcc-4.8
     - g++-4.8
 script:
-- sbt textLintAll textTestAll "textBuildHtml --gitbook=2.6.7" test &&
+- sbt textLintAll textTestAll textBuildHtml test &&
   wget -nv -O- https://raw.githubusercontent.com/kovidgoyal/calibre/614d94496efdcf960871429e1c090c56d2018f68/setup/linux-installer.py
   | python -c "import sys; main=lambda x,y:sys.stderr.write('Download failed\n');
   exec(sys.stdin.read()); main('~/calibre-bin', True)" >/dev/null &&
   export PATH="~/calibre-bin/calibre/:/home/travis/calibre-bin/calibre/:$PATH" &&
-  sbt "textBuildEpub --gitbook=2.6.7"
+  sbt "textBuildEpub"
 after_success:
 - "./deploy.sh"
 after_script:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ Macでのインストールは例えば以下のようになる。
 
 ```
 brew cask install calibre
-ln -s ~/Applications/calibre.app/Contents/console.app/Contents/MacOS/ebook-convert /usr/local/bin/ebook-convert
 ```
 
 ビルドは以下のように行うことが出来る。

--- a/book.json
+++ b/book.json
@@ -1,4 +1,5 @@
 {
+  "root": "./gitbook",
   "structure": {
     "readme": "INTRODUCTION.md",
     "summary": "SUMMARY.md"

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,7 @@ chmod 600 ~/.ssh/deploy.key &&
 git config --global user.email "6b656e6a69@gmail.com" &&
 git config --global user.name "xuwei-k" &&
 mv gitbook/_book ../ &&
-mv gitbook/book.epub ../_book/scala_text.epub &&
+mv gitbook/scala_text.epub ../_book/scala_text.epub &&
 git fetch origin gh-pages:gh-pages &&
 git clean -fdx &&
 git checkout gh-pages &&

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gitbook-plugin-footnote-string-to-number": "0.0.2",
     "gitbook-plugin-include-codeblock": "1.8.2",
     "gitbook-plugin-japanese-support": "0.0.1",
-    "gitbook-plugin-regexplace": "1.0.6",
+    "gitbook-plugin-regexplace": "2.0.0",
     "kramed": "0.5.6",
     "mocha": "2.4.5",
     "npm-check-updates": "2.6.5",

--- a/project/GitBook.scala
+++ b/project/GitBook.scala
@@ -4,21 +4,22 @@ import tut.Plugin._
 
 object GitBook extends NpmCliBase {
   val gitbookBin = nodeBin / cmd("gitbook")
+  val gitbookVersion = "3.0.3"
 
   sealed trait Format {def command: String}
   object Format {
-    case object Html extends Format { def command = "build" }
-    case object Epub extends Format { def command = "epub" }
-    case object Pdf extends Format { def command = "pdf" }
+    case object Html extends Format { def command = s"build $bookJsonDir $bookDestDir/_book" }
+    case object Epub extends Format { def command = s"epub  $bookJsonDir $bookDestDir/scala_text.epub" }
+    case object Pdf extends Format { def command = s"pdf  $bookJsonDir $bookDestDir/scala_text.pdf" }
   }
 
   def buildBook(format: Format) = Def.inputTask[Unit] {
     val options = rawStringArg("<gitbook command>").parsed
-    printRun(Process(s"$gitbookBin  ${format.command} $bookBuildDir $options"))
+    printRun(Process(s"$gitbookBin  ${format.command} --gitbook=$gitbookVersion $options"))
 
     if(format == Format.Html) {
       println("chrome48でcssの`text-rendering:optimizeLegibility`のレンダリングが高コストであるため該当cssを削除します")
-      val cssPath = s"$bookBuildDir/_book/gitbook/style.css"
+      val cssPath = s"$bookDestDir/_book/gitbook/style.css"
       val orig = IO.read(file(cssPath), IO.utf8)
       val modified = orig.replace("text-rendering:optimizeLegibility;", "")
       IO.write(file(cssPath), modified, IO.utf8)
@@ -36,18 +37,10 @@ object GitBook extends NpmCliBase {
     textPluginInstall := printRun(Process(s"$gitbookBin install")),
     textHelpGitBook := printRun(Process(s"$gitbookBin help")),
     textBuildHtml := buildBook(Format.Html).dependsOn(tut).evaluated,
-    /*
-     foo.mdだけ更新があるときに単純にsbt buildを実行すると
-     tutで全ファイルがコンパイル -> gitbook build が走ってしまいそれなりに時間がかかる。
-     その対策のために現状はtutOnly foo.md -> buildOnlyとすれば
-     foo.mdだけコンパイルされて更新される -> gitbook buildがかかるようになっている。
-
-     本当は buildOnly foo.md とだけやれば
-     tutOnly foo.md -> gitbook build
-     が自動でh実行されるようにしたかったが書き方がよくわからず挫折した。
-    */
-    textBuildOnly := buildBook(Format.Html).evaluated,
     textBuildEpub := buildBook(Format.Epub).dependsOn(tut).evaluated,
-    textBuildPdf := sys.error("pdf-convertで利用するcalibreがcentOS6で上手く動かないので停止中")
+    textBuildPdf := sys.error("pdf-convertで利用するcalibreがcentOS6で上手く動かないので停止中"),
+
+    // tutを通さずビルドする（srcディレクトリからのコピーは行われないので tutOnly foo.md => textBuildOnly の順で実行する）
+    textBuildOnly := buildBook(Format.Html).evaluated
   )
 }

--- a/project/NpmCliBase.scala
+++ b/project/NpmCliBase.scala
@@ -9,10 +9,15 @@ trait NpmCliBase {
   val srcDir = file("src")
   def srcMarkdowns = srcDir.listFiles("*.md").filterNot(f => f.getPath.contains("src/example_projects/"))
 
-  // gitbookのビルドの起点になるディレクトリ(book/_book/index.htmlが生成される)
-  val bookBuildDir = file("gitbook")
+  // book.jsonがあるディレクトリ
+  val bookJsonDir = file(".")
+
+  // gitbookのビルドの起点/成果物が入るディレクトリ(gitbook/_book/index.html, gitbook/scala_text.epubが生成される)
+  val bookDestDir = file("gitbook")
+
   // tutで処理済みのmarkdownファイルが入るディレクトリ。これがgitbook buildされる
-  val compiledSrcDir = bookBuildDir
+  // book.jsonのrootにも指定されている。
+  val compiledSrcDir = bookDestDir
 
   // リンク切れチェックのようなテストが入るディレクトリ
   val testDir = file("test")


### PR DESCRIPTION
#173 の出し直しです。

上げました。見た目に関する非互換な修正があるかもしれないのでビルド後のhtmlを一通り見る必要があります。 http://dwango.github.io/scala_text_previews/gitbook-v3

以下、あんまり読まなくても良いトラブルシュートです。

```
前提
- tut通す都合上、srcファイルをtutで変換してgitbookディレクトリにコピー => gitbook buildみたいな普通やらないプロセスになっていた
- 中間生成物が入るだけのgitbookディレクトリは当然 gitignoreに入れていた

v3に上げたときおこったこと
- gitbook build gitbook/のように実行すると、`gitbook/node_modules` を作らないとpluginが解決されないようになった。（バグ？）
- 上記の事柄自体はbook.jsonにrootプロパティを指定やれば解決する
- gitbookの仕様的にgitignoreに指定されているファイルはビルドに含まれないようになっている(v3よりも前からそういう仕様)
- v3に上げる前まではrootプロパティを指定していなかったため、gitignoreに指定されている `gitbook` ディレクトリの無視設定はgitbookプロセスからは効かない状態だった。
- rootディレクトリ変更機能を使うようにしたので、gitbookディレクトリが実際に無視されるようになりfile not foundが多発した
- `.bookignore`で強制的にビルドに加える設定を行って↑の問題を回避した
```

fix https://github.com/dwango/scala_text/issues/172