### PR TITLE
非推奨の警告修正

### DIFF
--- a/src/test.md
+++ b/src/test.md
@@ -407,7 +407,7 @@ libraryDependencies += "org.mockito" % "mockito-core" % "1.10.19" % "test"
 ```tut:silent
 import org.scalatest.{FlatSpec, DiagrammedAssertions}
 import org.scalatest.concurrent.Timeouts
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 
 class CalcSpec extends FlatSpec with DiagrammedAssertions with Timeouts with MockitoSugar {


### PR DESCRIPTION
scalatest 3.0.0から非推奨(package変わった)

以下のコミット
https://github.com/dwango/scala_text/commit/5a37f1fc45e2b4099bebbddd257514c2657213e4
で、同時に変更するべきだったもの。

- https://github.com/scalatest/scalatest/blob/release-3.0.0/scalatest/src/main/scala/org/scalatest/mock/package.scala#L38-L42
- https://github.com/scalatest/scalatest/commit/9bfaa679177299f60b9fa261f6f273aa16fe5a0d