### PR TITLE
Scala 2.12対応

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,9 @@ tutSourceDirectory := srcDir
 tutTargetDirectory := compiledSrcDir
 
 libraryDependencies ++= Seq(
-  "org.scala-sbt" % "sbt" % "1.0.0-M4",
+  // sbt_2.12はしばらく出ない可能性が高いので下記PR内容をリバートしている
+  // https://github.com/dwango/scala_text/pull/118
+  // "org.scala-sbt" % "sbt" % "1.0.0-M4",
   "org.mockito" % "mockito-core" % "1.10.19",
   "org.scalacheck" %% "scalacheck" % "1.13.4",
   "org.scalatest" %% "scalatest" % "3.0.0" // tutで使うので、テストライブラリだが、わざとcompileスコープ

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val textTestAll = taskKey[Unit]("test scala, links")
 
 name := "textbook"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 
 tutSettings
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.5")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.6")

--- a/src/advanced-trait-di.md
+++ b/src/advanced-trait-di.md
@@ -30,7 +30,7 @@
 - この他のストレージ機能とパスワード機能のメソッドは内部的に使われるのみである
 
 上記のプログラムでは実際に動かすことができるように[ScalikeJDBC](https://github.com/scalikejdbc/scalikejdbc)というデータベース用のライブラリとjBCryptというパスワースのハッシュ値を計算するライブラリが使われていますが、実装の詳細を理解する必要はありません。
-既にメソッドの実装を説明したことがある場合は実装を省略し[`???`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/Predef.scala#L230)で書くことがあります。
+既にメソッドの実装を説明したことがある場合は実装を省略し[`???`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/Predef.scala#L284)で書くことがあります。
 
 ## リファクタリング：公開する機能を制限する
 

--- a/src/basic.md
+++ b/src/basic.md
@@ -20,7 +20,7 @@ $ sbt console
 とコマンドを打ってみましょう。
 
 ```
-Welcome to Scala version 2.11.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_45).
+Welcome to Scala version 2.12.0 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_45).
 Type in expressions to have them evaluated.
 Type :help for more information.
 

--- a/src/collection.md
+++ b/src/collection.md
@@ -22,7 +22,7 @@ mutableなコレクションを効果的に使えばプログラムの実行速�
 - `Map`(immutable)・`Map`(mutable)
 - `Set`(immutable)・ `Set`(mutable)
 
-## [Array](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/Array.scala)
+## [Array](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/Array.scala)
 
 まずは大抵のプログラミング言語にある配列です。
 
@@ -96,7 +96,7 @@ arr
 
 <!-- end answer -->
 
-### [Range](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/Range.scala)
+### [Range](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/immutable/Range.scala)
 
 `Range`は範囲を表すオブジェクトです。`Range`は直接名前を指定して生成するより、`to`メソッドと`until`メソッドを用いて呼びだすことが多いです。また、`toList`メソッドを用いて、その範囲の数値の列を後述する`List`に変換することができます。では、早速REPLで`Range`を使ってみましょう。
 
@@ -112,7 +112,7 @@ arr
 
 `to`は右の被演算子を含む範囲を、`until`は右の被演算子を含まない範囲を表していることがわかります。また、`Range`は`toList`で後述する`List`に変換することができることもわかります。
 
-### [List](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/List.scala)
+### [List](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/immutable/List.scala)
 
 さて、導入として大抵の言語にある`Array`を出しましたが、Scalaでは`Array`を使うことはそれほど多くありません。代わりに`List`や
 `Vector`といったデータ構造をよく使います（`Vector`については後述します）。`List`の特徴は、一度作成したら中身を
@@ -132,9 +132,9 @@ lst(0) = 7
 
 ### Nil：空のList
 
-まず最初に紹介するのは`Nil`です。Scalaで空の`List`を表すには`Nil`というものを使います。Rubyなどでは`nil`は言語上かなり特別な意味を持ちますが、Scalaではデフォルトでスコープに入っているということ以外は特別な意味はなく[単にobjectです](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/List.scala#L417)。Nilは単体では意味がありませんが、次に説明する`::`と合わせて用いることが多いです。
+まず最初に紹介するのは`Nil`です。Scalaで空の`List`を表すには`Nil`というものを使います。Rubyなどでは`nil`は言語上かなり特別な意味を持ちますが、Scalaではデフォルトでスコープに入っているということ以外は特別な意味はなく[単にobjectです](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/immutable/List.scala#L414)。Nilは単体では意味がありませんが、次に説明する`::`と合わせて用いることが多いです。
 
-### [:: - Listの先頭に要素をくっつける](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/List.scala#L111)
+### [:: - Listの先頭に要素をくっつける](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/immutable/List.scala#L111)
 
 `::`（コンスと読みます）は既にある`List`の先頭に要素をくっつけるメソッドです。これについては、REPLで結果をみた方が早いでしょう。
 
@@ -590,7 +590,7 @@ List(1, 2, 3, 4) :+ 5 // 注意！末尾への追加は、Listの要素数分か
 
 `mkString`をはじめとした`List`の色々なメソッドを紹介してきましたが、実はこれらの大半は`List`特有ではなく、既に紹介した`Range`や`Array`、これから紹介する他のコレクションでも同様に使うことができます。何故ならばこれらの操作の大半は特定のコレクションではなく、コレクションのスーパータイプである共通のトレイト中に宣言されているからです。もちろん、`List`に要素を加える処理と`Set`に要素を加える処理（`Set`に既にある要素は加えない）のように、中で行われる処理が異なることがあるので、その点は注意する必要があります。詳しくは[ScalaのAPIドキュメント](http://www.scala-lang.org/api/current/index.html)を探索してみましょう。
 
-### [Vector](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/Vector.scala)
+### [Vector](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/immutable/Vector.scala)
 
 `Vector`は少々変わったデータ構造です。`Vector`は一度データ構造を構築したら変更できないimmutableなデータ構造
 です。要素へのランダムアクセスや長さの取得、データの挿入や削除、いずれの操作も十分に高速にできる比較的
@@ -611,11 +611,11 @@ Vector(1, 2, 3, 4, 5).updated(2, 5)
 `Map`はキーから値へのマッピングを提供するデータ構造です。他の言語では辞書や連想配列と呼ばれたりします。
 Scalaでは`Map`として一度作成したら変更できないimmutableな`Map`と変更可能なmutableな`Map`の2種類を提供しています。
 
-### [`scala.collection.immutable.Map`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/Map.scala) 
+### [`scala.collection.immutable.Map`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/immutable/Map.scala) 
 
 Scalaで何も設定せずにただ`Map`と書いた場合、`scala.collection.immutable.Map`が使われます。その名の通り、一度
-作成すると変更することはできません。内部の実装としては主に[`scala.collection.immutable.HashMap`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/HashMap.scala)と
-[`scala.collection.immutable.TreeMap`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/TreeMap.scala)の2種類がありますが、通常は`HashMap`が使われます。
+作成すると変更することはできません。内部の実装としては主に[`scala.collection.immutable.HashMap`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/immutable/HashMap.scala)と
+[`scala.collection.immutable.TreeMap`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/immutable/TreeMap.scala)の2種類がありますが、通常は`HashMap`が使われます。
 
 ```tut
 val m = Map("A" -> 1, "B" -> 2, "C" -> 3)
@@ -655,8 +655,8 @@ Set(1, 1, 2, 3, 4)
 ### `scala.collection.immutable.Set`
 
 Scalaで何も設定せずにただ`Set`と書いた場合、`scala.collection.immutable.Set`が使われます。immutableな`Map`の場合と
-同じく、一度作成すると変更することはできません。内部の実装としては、主に [`scala.collection.immutable.HashSet`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/HashSet.scala) と
-[`scala.collection.immutable.TreeSet`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/immutable/TreeSet.scala) の2種類がありますが、通常は`HashSet`が使われます。
+同じく、一度作成すると変更することはできません。内部の実装としては、主に [`scala.collection.immutable.HashSet`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/immutable/HashSet.scala) と
+[`scala.collection.immutable.TreeSet`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/immutable/TreeSet.scala) の2種類がありますが、通常は`HashSet`が使われます。
 
 ```tut
 val s = Set(1, 2, 3, 4, 5)
@@ -668,8 +668,8 @@ s // 元のSetはそのまま
 
 ### `scala.collection.mutable.Set`
 
-Scalaの変更可能な`Set`は`scala.collection.mutable.Set`にあります。主な実装としては、[`scala.collection.mutable.HashSet`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/mutable/HashSet.scala) 、
-[`scala.collection.mutable.TreeSet`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/collection/mutable/TreeSet.scala)がありますが、通常は`HashSet`が使われます。
+Scalaの変更可能な`Set`は`scala.collection.mutable.Set`にあります。主な実装としては、[`scala.collection.mutable.HashSet`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/mutable/HashSet.scala) 、
+[`scala.collection.mutable.TreeSet`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/collection/mutable/TreeSet.scala)がありますが、通常は`HashSet`が使われます。
 
 ```tut
 import scala.collection.mutable

--- a/src/error-handling.md
+++ b/src/error-handling.md
@@ -155,7 +155,7 @@ Javaのエラー処理では例外が中心的な役割を担っていました�
 
 ここでは正常の値とエラー値のどちらかを表現できるデータ構造の紹介を通じて、Scalaの関数型のエラー処理の方法を見ていきます。
 
-### [Option](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/Option.scala)
+### [Option](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/Option.scala)
 
 OptionはScalaでもっとも多用されるデータ型の1つです。
 前述のとおりJavaのnullの代替として使われることが多いデータ型です。
@@ -481,7 +481,7 @@ for { i1 <- v1
 
 <!-- end answer -->
 
-### [Either](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/util/Either.scala)
+### [Either](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/util/Either.scala)
 
 Optionによりnullを使う必要はなくなりましたが、いっぽうでOptionでは処理が成功したかどうかしかわからないという問題があります。
 Noneの場合、値が取得できなかったことはわかりますが、エラーの状態は取得できないので、使用できるのはエラーの種類が問題にならないような場合のみです。
@@ -648,7 +648,7 @@ Rightが正常な値として用いられることが多いとすれば、ほと
 このScalaのEitherの仕様はHaskellのEitherのような暗黙的にRightを優先するのに比べてわずらわしいと言われることもあります。
 とりあえずEitherのmapやflatMapなどを使う場合はrightでRightProjectionに変化させると覚えてしまってよいと思います。
 
-### [Try](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/util/Try.scala)
+### [Try](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/util/Try.scala)
 
 ScalaのTryはEitherと同じように正常な値とエラー値のどちらかを表現するデータ型です。
 Eitherとの違いは、2つの型が平等ではなく、エラー値がThrowableに限定されており、型引数を1つしか取らないことです。
@@ -684,7 +684,7 @@ for {
 } yield i1 * i2 * i3
 ```
 
-#### [`NonFatal`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/util/control/NonFatal.scala)の例外
+#### [`NonFatal`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/util/control/NonFatal.scala)の例外
 
 `Try.apply`がcatchするのはすべての例外ではありません。
 NonFatalという種類の例外だけです。

--- a/src/error-handling.md
+++ b/src/error-handling.md
@@ -568,85 +568,24 @@ Eitherを使う場合はこのテクニックを覚えておいたほうがい�
 
 #### EitherのmapとflatMap
 
-以上、見てきたように格納できるデータが増えているという点でEitherはOptionの拡張版に近いのですが、ScalaのEitherはmapとflatMapの動作にちょっと癖があります。
-ScalaのEitherはOptionとは違い、直接mapやflatMapメソッドを持ちません。
-Eitherオブジェクトのメソッドを見てみますと、
+以上、見てきたように格納できるデータが増えているという点でEitherはOptionの拡張版に近いです。
+Optionと同様にEitherもfor式を使って複数のEitherを組み合わせることができます。
+EitherにはRight, Leftの2つの値がありますが、ScalaのEitherではRightが正常な値になることが多いため、mapやflatMapではRightの値が利用されます。[^right-either]
 
-```scala
-scala> val v: Either[String, Int] = Right(123)
-v: Either[String,Int] = Right(123)
-
-scala> v.
-asInstanceOf   fold   isInstanceOf   isLeft   isRight   joinLeft   joinRight   left   right   swap   toString
-```
-
-`fold`や`isLeft`や`isRight`などはOptionで同じようなメソッドがありましたが、肝心のmapやflatMapがありません。
-これではfor式を使って複数のEitherを組み合わせることができません。
-
-これにはScalaのEitherが左右の型を平等で扱っているという理由があります。
-たとえば自作のmapメソッドを作ることを考えてみましょう。
-mapメソッドは関数をコンテナの中身に適用できるようにするというものでした。
-Eitherの左右が平等に扱われると考えた場合、mapメソッドは左右のどちらの値に適用すればいいのでしょうか？
-この答えには2つのアプローチが考えられます。
-
-- 暗黙的に左右どちらかのうち片方を優先し、そちらに関数を適用する（たとえばRightが正常な値になることが多いならRightを暗黙的に優先するとか）
-- 明示的に左右どちらを優先するか指定する
-
-前者はHaskellのアプローチで、後者がScalaのアプローチになります[^right-either]。
-上記のEitherのメソッドに`left`と`right`というものがありました。
-これが左右どちらを優先するのか決めるメソッドです。
-
-試しに`right`メソッドを使ってみましょう。
-
-```scala
-scala> val v: Either[String, Int] = Right(123)
-v: Either[String,Int] = Right(123)
-
-scala> val e = v.right
-e: scala.util.Either.RightProjection[String,Int] = RightProjection(Right(123))
-
-scala> e.
-asInstanceOf   canEqual   copy   e   exists   filter   flatMap   forall   foreach   get   getOrElse   isInstanceOf   map   productArity   productElement   productIterator   productPrefix   toOption   toSeq   toString
-```
-
-Eitherに`right`メソッドを使ったら`RightProjection`というオブジェクトになりました。
-そして、この`RightProjection`オブジェクトを見てみると、ようやくListやOptionで見慣れたようなメソッドが出てきました。
-これらのメソッドはEitherのRightの値に対しておこなわれるメソッドということです。
-
-ためしに`RightProjection`の`map`メソッドを使ってみましょう[^product-with-serializable]。
+ためしに`Either`の`map`メソッドを使ってみましょう
 
 ```tut
 val v: Either[String, Int] = Right(123)
 
-v.right.map(_ * 2)
+v.map(_ * 2)
+
+val v2: Either[String, Int] = Left("a")
+v2.map(_ * 2) // v2がLeftなので実行されない
 ```
 
 これでmapを使って値を二倍にする関数をRightに適用できました。
-ちなみにEitherがLeftの場合は何の処理もおこなわれません。
+EitherがLeftの場合は何の処理もおこなわれません。
 これはOptionでNoneに対してmapを使った場合に何の処理もおこなわれないという動作に似ていますね。
-
-注意してほしいのはRightProjectionのmapメソッドの返り値はEitherであるという点です。
-つまりmapやflatMapを連鎖して使う場合には毎回EitherをRightProjectionに変化させる必要があるということです。
-
-Optionのときの掛け算の例をEitherで書いてみると、
-
-```tut
-val v1: Either[String, Int] = Right(3)
-
-val v2: Either[String, Int] = Right(5)
-
-val v3: Either[String, Int] = Right(7)
-
-for {
-  i1 <- v1.right
-  i2 <- v2.right
-  i3 <- v3.right
-} yield i1 * i2 * i3
-```
-
-Rightが正常な値として用いられることが多いとすれば、ほとんどのEitherはRightProjectionに変化させて使うことになります。
-このScalaのEitherの仕様はHaskellのEitherのような暗黙的にRightを優先するのに比べてわずらわしいと言われることもあります。
-とりあえずEitherのmapやflatMapなどを使う場合はrightでRightProjectionに変化させると覚えてしまってよいと思います。
 
 ### [Try](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/util/Try.scala)
 
@@ -844,9 +783,9 @@ object MainRefactored {
   // 本質的に何をしているかわかりやすくリファクタリング
   def getPostalCodeResult(userId: Int): PostalCodeResult = {
     (for {
-      user <- findUser(userId).right
-      address <- findAddress(user).right
-      postalCode <- findPostalCode(address).right
+      user <- findUser(userId)
+      address <- findAddress(user)
+      postalCode <- findPostalCode(address)
     } yield Success(postalCode)).merge
   }
 
@@ -856,8 +795,8 @@ object MainRefactored {
 
   def findAddress(user: User): Either[Failure, Address] = {
     for {
-      addressId <- user.addressId.toRight(UserNotHasAddress).right
-      address <- addressDatabase.get(addressId).toRight(AddressNotFound).right
+      addressId <- user.addressId.toRight(UserNotHasAddress)
+      address <- addressDatabase.get(addressId).toRight(AddressNotFound)
     } yield address
   }
 
@@ -880,15 +819,13 @@ object MainRefactored {
 ```scala
   def getPostalCodeResult(userId: Int): PostalCodeResult = {
     (for {
-      user <- findUser(userId).right
-      address <- findAddress(user).right
-      postalCode <- findPostalCode(address).right
+      user <- findUser(userId)
+      address <- findAddress(user)
+      postalCode <- findPostalCode(address)
     } yield Success(postalCode)).merge
   }
 ```
 getPostalCodeResultが本質的に何をしているのかが非常にわかりやすいコードとなりました。何をしているかというと、
-Eitherではfor式を直接つかえないので`.right`というメソッドで、RightProjectionという型にして、
-for式が利用できる形に変換しています。そのあと、mergeメソッドにより中身を畳み込んで取得しています。
+for式で値を取得した後、mergeメソッドにより中身を畳み込んで取得しています。
 
-[^product-with-serializable]: Scala2.11以前だと`Product with Serializable with scala.util.Either`というような変な型になりますが、実用上問題ないので、ひとまず気にしなくてよいです。この変な型になる問題はScala2.12以降では修正されています。 https://github.com/scala/scala/pull/4355 https://issues.scala-lang.org/browse/SI-9173
-[^right-either]: 今年リリース予定のScala 2.12では、Haskellと同じようにRight優先になります。
+[^right-either]: Scala 2.11までは、両者の値を平等に扱っていたため `.right` や `.left` を用いてどちらの値をmapに渡すかを明示する必要がありました。

--- a/src/example_projects/trait-example/build.sbt
+++ b/src/example_projects/trait-example/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 
 libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % "2.4.2",

--- a/src/example_projects/trait-example/build.sbt
+++ b/src/example_projects/trait-example/build.sbt
@@ -1,6 +1,6 @@
 scalaVersion := "2.12.0"
 
 libraryDependencies ++= Seq(
-  "org.scalikejdbc" %% "scalikejdbc" % "2.4.2",
+  "org.scalikejdbc" %% "scalikejdbc" % "2.5.0-RC2",
   "org.mindrot"     %  "jbcrypt"     % "0.3m"
 )

--- a/src/example_projects/trait-refactored-example/build.sbt
+++ b/src/example_projects/trait-refactored-example/build.sbt
@@ -1,7 +1,7 @@
 scalaVersion := "2.12.0"
 
 libraryDependencies ++= Seq(
-  "org.scalikejdbc" %% "scalikejdbc" % "2.4.2",
+  "org.scalikejdbc" %% "scalikejdbc" % "2.5.0-RC2",
   "org.mindrot"     %  "jbcrypt"     % "0.3m",
   "org.scalatest"   %% "scalatest"   % "3.0.0" % "test"
 )

--- a/src/example_projects/trait-refactored-example/build.sbt
+++ b/src/example_projects/trait-refactored-example/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 
 libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % "2.4.2",

--- a/src/function.md
+++ b/src/function.md
@@ -1,7 +1,7 @@
 # Scalaの関数
 
 Scalaの関数は、他の言語の関数と扱いが異なります。Scalaの関数は単に
-[`Function0`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/Function0.scala) 〜 [`Function22`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/Function22.scala) までのトレイトの無名サブクラスのインスタンスなのです。
+[`Function0`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/Function0.scala) 〜 [`Function22`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/Function22.scala) までのトレイトの無名サブクラスのインスタンスなのです。
 
 たとえば、2つの整数を取って加算した値を返す`add`関数は次のようにして定義することができます：
 

--- a/src/future-and-promise.md
+++ b/src/future-and-promise.md
@@ -30,9 +30,7 @@ JVM系の言語では、マルチスレッドで並行処理を使った非同�
 
 [Future](http://www.scala-lang.org/api/current/index.html#scala.concurrent.Future)とは、
 非同期に処理される結果が入ったOption型のようなものです。
-その処理が終わっているのかどうかや（isCompleted）、正しく終わった時の処理を適用する（onSuccess）、
-例外が起こったときの処理を適用する（onFailure）といったことが可能な他、
-flatMapやfilter、for式の適用といったようなOptionやListでも利用できる性質も持ち合わせています。
+mapやflatMapやfilter、for式の適用といったようなOptionやListでも利用できる性質を持っています。
 
 ライブラリやフレームワークの処理が非同期主体となっている場合、
 このFutureは基本的で重要な役割を果たすクラスとなります。
@@ -57,7 +55,7 @@ object FutureSample extends App {
     s + " future!"
   }
 
-  f.onSuccess { case s: String =>
+  f.foreach { case s: String =>
     println(s)
   }
 
@@ -66,6 +64,21 @@ object FutureSample extends App {
   Thread.sleep(5000) // Hello future!
 
   println(f.isCompleted) // true
+
+  val f2: Future[String] = Future {
+    Thread.sleep(1000)
+    throw new RuntimeException("わざと失敗")
+  }
+
+  f2.failed.foreach { case e: Throwable =>
+    println(e.getMessage)
+  }
+
+  println(f2.isCompleted) // false
+
+  Thread.sleep(5000) // わざと失敗
+
+  println(f2.isCompleted) // true
 }
 ```
 
@@ -74,6 +87,9 @@ object FutureSample extends App {
 ```
 false
 Hello future!
+true
+false
+わざと失敗
 true
 ```
 
@@ -117,8 +133,8 @@ object FutureSample extends App {
 
   }
 
-  f.onSuccess { case s: String =>
-    println(s"[ThreadName] In onSuccess: ${Thread.currentThread.getName}")
+  f.foreach { case s: String =>
+    println(s"[ThreadName] In Success: ${Thread.currentThread.getName}")
     println(s)
   }
 
@@ -138,12 +154,12 @@ false
 [ThreadName] In Future: ForkJoinPool-1-worker-5
 [ThreadName] In App: main
 true
-[ThreadName] In onSuccess: ForkJoinPool-1-worker-5
+[ThreadName] In Success: ForkJoinPool-1-worker-5
 Hello future!
 ```
 
 となります。以上のコードではそれぞれのスレッド名を各箇所について出力してみました。
-非常に興味深い結果ですね。`Future`と`onSuccess`に渡した関数に関しては、
+非常に興味深い結果ですね。`Future`と`foreach`に渡した関数に関しては、
 `ForkJoinPool-1-worker-5`というmainスレッドとは異なるスレッドで実行されています。
 
 つまりFutureを用いることで知らず知らずのうちのマルチスレッドのプログラミングが実行されていたということになります。
@@ -187,7 +203,7 @@ object FutureOptionUsageSample extends App {
 この処理では、3000ミリ秒を上限としたランダムな時間を待ってその待ったミリ秒を返すFutureを定義しています。
 ただし、1000ミリ秒未満しか待たない場合には失敗とみなし例外を投げます。
 この最初にえられるFutureを`futureMilliSec`としていますが、その後、`map`メソッドを利用して`Int`のミリ秒を`Doubule`の秒に変換しています。
-なお先ほどと違ってこの度は、`onSuccess`ではなく`onComplete`を利用して成功と失敗の両方の処理を記述しました。
+なお先ほどと違ってこの度は、`foreach`ではなく`onComplete`を利用して成功と失敗の両方の処理を記述しました。
 
 以上の実装のようにFutureは結果をOptionのように扱うことができるわけです。
 無論mapも使えますがOptionがネストしている場合にflatMapを利用できるのと同様に、
@@ -365,13 +381,13 @@ object CountDownLatchSample extends App {
     Thread.sleep(waitMilliSec)
     waitMilliSec
   }
-  futures.foreach { f => f.onSuccess {case waitMilliSec =>
+  futures.foreach { f => f.foreach {case waitMilliSec =>
     val index = indexHolder.getAndIncrement
     if(index < promises.length) {
       promises(index).success(waitMilliSec)
     }
   }}
-  promises.foreach { p => p.future.onSuccess{ case waitMilliSec => println(waitMilliSec)}}
+  promises.foreach { p => p.future.foreach { case waitMilliSec => println(waitMilliSec)}}
   Thread.sleep(5000)
 }
 ```

--- a/src/implicit.md
+++ b/src/implicit.md
@@ -55,7 +55,7 @@ implicit def enrichString(arg: String): RichString = new RichString(arg)
 ```
 
 ちゃんと文字列の末尾に`":-)"`を追加する`smile`メソッドが定義できています。さて、ここでひょっとしたら気がついた方もいるかもしれませんが、implicit conversionはそのままでは、既存のクラスへのメソッド追加のために使用するには冗長であるということです。Scala 2.10からは、classにimplicit
-というキーワードをつけることで同じようなことができるようになりました（皆さんが学習するのはScala 2.11なので気にする必要はありません。
+というキーワードをつけることで同じようなことができるようになりました（皆さんが学習するのはScala 2.12なので気にする必要はありません。
 
 ### Implicit Class
 
@@ -329,12 +329,12 @@ println(sum(List(Point(1, 2), Point(3, 4), Point(5, 6)))) // Point(9, 12)
 
 型クラス：
 
-* [Numeric[T]](http://www.scala-lang.org/api/2.11.8/index.html#scala.math.Numeric)
+* [Numeric[T]](http://www.scala-lang.org/api/2.12.0/scala/math/Numeric.html)
 
 型クラスのインスタンス：
 
-* [IntIsIntegral](http://www.scala-lang.org/api/2.11.8/index.html#scala.math.Numeric$$IntIsIntegral$)
-* [DoubleAsIfIntegral](http://www.scala-lang.org/api/2.11.8/index.html#scala.math.Numeric$$DoubleAsIfIntegral$)
+* [IntIsIntegral](http://www.scala-lang.org/api/2.12.0/scala/math/Numeric$$IntIsIntegral$.html)
+* [DoubleAsIfIntegral](http://www.scala-lang.org/api/2.12.0/scala/math/Numeric$$DoubleAsIfIntegral$.html)
 
 <!-- end answer -->
 

--- a/src/object.md
+++ b/src/object.md
@@ -23,7 +23,7 @@ object オブジェクト名 extends クラス名 with トレイト名1 with ト
 }
 ```
 
-のようになります。Scalaでは標準で[`Predef`という`object`](https://github.com/scala/scala/blob/v2.11.8/src/library/scala/Predef.scala)が定義・インポート
+のようになります。Scalaでは標準で[`Predef`という`object`](https://github.com/scala/scala/blob/v2.12.0/src/library/scala/Predef.scala)が定義・インポート
 されており、これは最初の使い方に当てはまります。たとえば、println()などとなにげなく
 使っていたメソッドも実はPredef objectのメソッドなのです。
 

--- a/src/sbt-compile-execute.md
+++ b/src/sbt-compile-execute.md
@@ -40,7 +40,7 @@ sandbox
 
 ```tut:silent
 // build.sbt
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xlint")
 ```

--- a/src/sbt-compile-execute.md
+++ b/src/sbt-compile-execute.md
@@ -1,9 +1,5 @@
 # sbtでプログラムをコンパイル・実行する
 
-```tut:invisible
-import sbt._, syntax._, Keys._
-```
-
 前節まででは、REPLを使ってScalaのプログラムを気軽に実行してみました。この節ではScalaのプログラムをsbtでコンパイルして実行する方法を学びましょう。
 まずはREPLの時と同様にHello, World!を表示するプログラムを作ってみましょう。その前に、REPLを抜けましょう。REPLを抜けるには、REPLから以下のように
 入力します[^repl-quit]。
@@ -38,7 +34,7 @@ sandbox
 
 今回の_build.sbt_にはScalaのバージョンと一緒に`scalac`の警告オプションも有効にしてみましょう。
 
-```tut:silent
+```scala
 // build.sbt
 scalaVersion := "2.12.0"
 

--- a/src/sbt-install.md
+++ b/src/sbt-install.md
@@ -1,9 +1,5 @@
 # sbtをインストールする
 
-```tut:invisible
-import sbt._, syntax._, Keys._
-```
-
 現実のScalaアプリケーションでは、Scalaプログラムを手動でコンパイル[^scalac]することは非常に稀で、
 標準的なビルドツールである[sbt（Simple Build Tool）](http://www.scala-sbt.org/release/tutorial/ja/Setup.html)というツールを用いることになり
 ます。ここでは、sbtのインストールについて説明します。
@@ -79,7 +75,7 @@ scala> :quit
 になってしまうので、こちらが指定したバージョンのScalaでREPLを起動したい場合は、同じディレクトリに
 _build.sbt_というファイルを作成し、
 
-```tut:silent
+```scala
 scalaVersion := "2.12.0"
 ```
 

--- a/src/sbt-install.md
+++ b/src/sbt-install.md
@@ -80,7 +80,7 @@ scala> :quit
 _build.sbt_というファイルを作成し、
 
 ```tut:silent
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 ```
 
 としてやると良いです。この_*.sbt_がsbtのビルド定義ファイルになるのですが、今はREPLに慣れてもらう

--- a/src/test.md
+++ b/src/test.md
@@ -432,7 +432,7 @@ class CalcSpec extends FlatSpec with DiagrammedAssertions with Timeouts with Moc
 
 テストを行った際に、テストが機能のどれぐらいを網羅できているのかを知る方法として、
 コードカバレッジを計測するという方法があります。
-ここでは、[scoverage](https://github.com/scoverage/scalac-scoverage-plugin)を利用します。
+ここでは、[scoverage](https://github.com/scoverage/scalac-scoverage-plugin)を利用します。[^scoverage]
 
 過去、[SCCT](http://mtkopone.github.io/scct/)というプロダクトがあったのですが紆余曲折あり、
 今はあまりメンテンナンスされていません。
@@ -521,3 +521,4 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 [^power-assert]: 渡された条件式の実行過程をダイアグラムで表示する`assert`は、一般に“power assert”と呼ばれています
 [^predef-assert]: Scalaには`Predef`にも`assert`が存在しますが、基本的に使うことはありません
 [^xutp]: モック以外の仕組みについては[xUnit Test Patterns](http://xunitpatterns.com/)を参照してください
+[^scoverage]: 2016/11/4時点ではまだScala2.12では使うことが出来ませんが、近いうちに対応バージョンが出るはずです。 https://github.com/dwango/scala_text/pull/244

--- a/src/test.md
+++ b/src/test.md
@@ -133,7 +133,7 @@ name := "scalatest_study"
 
 version := "1.0"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 
@@ -145,8 +145,8 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 [info] Set current project to scalatest_study (in build file:/Users/dwango/workspace/scalatest_study/scalatest_study/)
 [info] Updating {file:/Users/dwango/workspace/scalatest_study/scalatest_study/}scalatest_study...
 [info] Resolving jline#jline;2.12.1 ...
-[info] downloading http://repo1.maven.org/maven2/org/scalatest/scalatest_2.11/3.0.0/scalatest_2.11-3.0.0.jar ...
-[info] 	[SUCCESSFUL ] org.scalatest#scalatest_2.11;3.0.0!scalatest_2.11.jar(bundle) (10199ms)
+[info] downloading http://repo1.maven.org/maven2/org/scalatest/scalatest_2.12/3.0.0/scalatest_2.12-3.0.0.jar ...
+[info] 	[SUCCESSFUL ] org.scalatest#scalatest_2.12;3.0.0!scalatest_2.12.jar(bundle) (10199ms)
 [info] Done updating.
 [success] Total time: 11 s, completed 2015/04/09 16:48:42
 ```
@@ -251,8 +251,8 @@ class CalcSpec extends FlatSpec with DiagrammedAssertions {
 ```
 [info] Loading project definition from /Users/dwango/workspace/scalatest_study/project
 [info] Set current project to scalatest_study (in build file:/Users/dwango/workspace/scalatest_study/)
-[info] Compiling 1 Scala source to /Users/dwango/workspace/scalatest_study/target/scala-2.11/classes...
-[info] Compiling 1 Scala source to /Users/dwango/workspace/scalatest_study/target/scala-2.11/test-classes...
+[info] Compiling 1 Scala source to /Users/dwango/workspace/scalatest_study/target/scala-2.12/classes...
+[info] Compiling 1 Scala source to /Users/dwango/workspace/scalatest_study/target/scala-2.12/test-classes...
 [info] CalcSpec:
 [info] sum関数
 [info] - should 整数の配列を取得し、それらを足し合わせた整数を返すことができる
@@ -271,7 +271,7 @@ class CalcSpec extends FlatSpec with DiagrammedAssertions {
 ```
 [info] Loading project definition from /Users/dwango/workspace/scalatest_study/project
 [info] Set current project to scalatest_study (in build file:/Users/dwango/workspace/scalatest_study/)
-[info] Compiling 1 Scala source to /Users/dwango/workspace/scalatest_study/target/scala-2.11/test-classes...
+[info] Compiling 1 Scala source to /Users/dwango/workspace/scalatest_study/target/scala-2.12/test-classes...
 [info] CalcSpec:
 [info] sum関数
 [info] - should 整数の配列を取得し、それらを足し合わせた整数を返すことができる *** FAILED ***
@@ -362,7 +362,7 @@ class CalcSpec extends FlatSpec with DiagrammedAssertions with Timeouts {
 ```
 [info] Loading project definition from /Users/dwango/workspace/scalatest_study/project
 [info] Set current project to scalatest_study (in build file:/Users/dwango/workspace/scalatest_study/)
-[info] Compiling 1 Scala source to /Users/dwango/workspace/scalatest_study/target/scala-2.11/test-classes...
+[info] Compiling 1 Scala source to /Users/dwango/workspace/scalatest_study/target/scala-2.12/test-classes...
 [info] CalcSpec:
 [info] sum関数
 [info] - should 整数の配列を取得し、それらを足し合わせた整数を返すことができる
@@ -449,7 +449,7 @@ resolvers += Classpaths.sbtPluginReleases
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
 ```
 
-その後、`sbt clean coverage test`を実行することで、`target/scala-2.11/scoverage-report/index.html`にレポートが出力されます。
+その後、`sbt clean coverage test`を実行することで、`target/scala-2.12/scoverage-report/index.html`にレポートが出力されます。
 
 ![Scoverage Code Coverage](img/scoverage_code_coverage.png)
 

--- a/src/test.md
+++ b/src/test.md
@@ -124,11 +124,7 @@ BDDでは、テスト内にそのプログラムに与えられた機能的な�
 
 `build.sbt`を用意して、以下を記述しておきます。
 
-```tut:invisible
-import sbt._, syntax._, Keys._
-```
-
-```tut:silent
+```scala
 name := "scalatest_study"
 
 version := "1.0"
@@ -398,7 +394,7 @@ BDDでテストを書くことによってテストによってどのような�
 ここでは、ドワンゴ社内で利用率の高いMockitoを利用してみましょう。
 `build.sbt`に以下を追記することで利用可能になります。
 
-```tut:silent
+```scala
 libraryDependencies += "org.mockito" % "mockito-core" % "1.10.19" % "test"
 ```
 
@@ -443,7 +439,7 @@ class CalcSpec extends FlatSpec with DiagrammedAssertions with Timeouts with Moc
 
 `project/plugins.sbt` に以下のコードを記述します。
 
-```tut:silent
+```scala
 resolvers += Classpaths.sbtPluginReleases
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
@@ -477,7 +473,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
 
 使い方は、`project/plugins.sbt` に以下のコードを記述します。
 
-```tut:silent
+```scala
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 ```
 


### PR DESCRIPTION
依存ライブラリの修正などは含まずテキストの中身を変更しているため現段階ではテストが通りません。

- [x] scalacheck_2.12
- [x] scalatest_2.12
- [x] tut_2.12
- [x] scalikejdbc(一旦RCで)
- [ ] scoverage 2.12対応 (build.sbtには無いが https://github.com/dwango/scala_text/blob/master/src/test.md#コードカバレッジの測定 で利用)

本文のビルドは出来る状態。
#118 をリバートした関係でチェック出来なくなっているがscoverageが未対応。
sbt-scoverage 1.5.0-RC2が依存しているscoverage 1.3.0-RC1がscala 2.12.0-RC1をサポートしているらしいのでもう少し待つ。 https://github.com/scoverage/scalac-scoverage-plugin/releases