### PR TITLE
gitbookバージョンを3.2.2へ更新

### DIFF
--- a/project/GitBook.scala
+++ b/project/GitBook.scala
@@ -4,7 +4,7 @@ import tut.Plugin._
 
 object GitBook extends NpmCliBase {
   val gitbookBin = nodeBin / cmd("gitbook")
-  val gitbookVersion = "3.1.1"
+  val gitbookVersion = "3.2.2"
 
   sealed trait Format {def command: String}
   object Format {


### PR DESCRIPTION
3.2.0 ~ 3.2.2 https://github.com/GitbookIO/gitbook/blob/3.2.2/CHANGES.md

markdown parserが変わりそうで変わってない（ロールバックした）ようなのであまり変更はなさそうです。


## 確認項目

- [x] ページを見ることが出来る
- [x] ページ遷移
- [x] ページ内リンク
- [x] 解答の開閉