### PR TITLE
検索の復活 & Forkmeボタン追加

### DIFF
--- a/book.json
+++ b/book.json
@@ -9,7 +9,8 @@
     "japanese-support",
     "footnote-string-to-number",
     "anchors",
-    "regexplace"
+    "regexplace",
+    "forkmegithub"
   ],
   "pluginsConfig": {
     "regexplace": {
@@ -17,6 +18,10 @@
         {"pattern": "<!-- begin answer id=\"(.*)\" style=\"(.*)\" -->", "flags": "g", "substitute": "<div><button type=\"button\" id=\"$1_show_answer_button\" style=\"display:block\" onclick=\"document.getElementById('$1').style.display='block'; document.getElementById('$1_show_answer_button').style.display='none'; document.getElementById('$1_hide_answer_button').style.display='block'; \">解答例を表示する</button><button type=\"button\" id=\"$1_hide_answer_button\" style=\"display:none\" onclick=\"document.getElementById('$1').style.display='none'; document.getElementById('$1_show_answer_button').style.display='block'; document.getElementById('$1_hide_answer_button').style.display='none'; \">解答例を隠す</button></div><div id=\"$1\" style=\"$2\">"},
         {"pattern": "<!-- end answer -->", "flags": "g", "substitute": "</div>"}
       ]
+    },
+    "forkmegithub": {
+      "url": "https://github.com/dwango/scala_text",
+      "color": "darkblue"
     }
   },
   "title": "Scala研修テキスト"

--- a/book.json
+++ b/book.json
@@ -5,7 +5,6 @@
     "summary": "SUMMARY.md"
   },
   "plugins": [
-    "-search",
     "include-codeblock",
     "japanese-support",
     "footnote-string-to-number",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gitbook-cli": "2.3.0",
     "gitbook-plugin-anchors": "0.7.1",
     "gitbook-plugin-footnote-string-to-number": "0.0.2",
+    "gitbook-plugin-forkmegithub": "^2.2.0",
     "gitbook-plugin-include-codeblock": "2.1.0",
     "gitbook-plugin-japanese-support": "0.0.1",
     "gitbook-plugin-regexplace": "2.1.2",


### PR DESCRIPTION
forkmeボタン https://github.com/mizunashi-mana/gitbook-plugin-forkmegithub を追加してみました。

また現状のscala_text( https://dwango.github.io/scala_text/ )はJSでエラーが出ているため正しくプラグインが機能しない状態だったようです。(そのため-searchがある状態だとボタンが表示されない）

久しぶりにsearchつけてみたところ、高速化されていたようでそこそこ使える雰囲気を感じたのでこの際ONにしてみました。

- [x] 検索で適当な日本語や英語を入力してみて検索が現実的な負荷で機能することを確認
- [x] 右上にfork meボタンが表示されていて、クリックすると http://github.com/dwango/scala_text に移動する