### PR TITLE
Promiseの例でprintlnが確実に実行されるよう修正

### DIFF
--- a/src/future-and-promise.md
+++ b/src/future-and-promise.md
@@ -287,10 +287,8 @@ object CompositeFutureSample extends App {
 
 ```tut:silent
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Promise, Future, Await}
+import scala.concurrent.{Promise, Future}
 import scala.util.{Success, Failure}
-import scala.language.postfixOps
-import scala.concurrent.duration._
 
 object PromiseSample extends App {
   val promiseGetInt: Promise[Int] = Promise[Int]
@@ -308,7 +306,7 @@ object PromiseSample extends App {
     promiseGetInt.success(1)
   }
 
-  Await.ready(futureByPromise, 5000 millisecond)
+  Thread.sleep(1000)
 }
 ```
 


### PR DESCRIPTION
私の環境(Mac OS 10.10.5, Scala 2.12.1)では、PromiseSampleがprintlnを完了する前にプロセス終了することがあります。修正後のコードの方が、printlnが完了してからプロセスが終了する可能性が高いと思います。
