### PR TITLE
章タイトルを変更

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -9,7 +9,7 @@
 - [トレイト](trait.md)
 - [型パラメータと変位指定](type-parameter.md)
 - [関数](function.md)
-- [Scalaのコレクションライブラリ](collection.md)
+- [コレクションライブラリ](collection.md)
 - [ケースクラスとパターンマッチング](case-class-and-pattern-matching.md)
 - [エラー処理](error-handling.md)
 - [Implicit](implicit.md)

--- a/src/collection.md
+++ b/src/collection.md
@@ -1,4 +1,4 @@
-# Scalaのコレクションライブラリ（immutableとmutable）
+# コレクションライブラリ（immutableとmutable）
 
 Scalaには配列（`Array`）やリスト（`List`）、連想配列（`Map`）、集合（`Set`）を扱うための豊富なライブラリがあります。これを使いこなすことで、Scalaでの
 プログラミングは劇的に楽になります。注意しなければならないのは、Scalaでは一度作成したら変更できない（immutable）なコレクションと


### PR DESCRIPTION
* 「Scalaのコレクションライブラリ」を「コレクションライブラリ」に
* Fix #264 