### PR TITLE
2.11までと思われるEither仕様の記述を削除しました。

### DIFF
--- a/src/error-handling.md
+++ b/src/error-handling.md
@@ -607,8 +607,6 @@ val v: Try[Int] = Try(throw new RuntimeException("to be caught"))
 
 この機能を使って、例外が起こりそうな箇所を`Try`で包み、Failureにして値として扱えるようにするのがTryの特徴です。
 
-またTryはEitherと違い、正常な値を片方に決めているのでmapやflatMapをそのまま使うことができます。
-
 ```tut
 val v1 = Try(3)
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:babel-register
+--compilers js:babel-core/register


### PR DESCRIPTION
Eitherの説明部分は2.12を前提としている（map, flatMapの適用にRight, Leftの指定は不要）ようでしたので、Tryの説明に出るこの記述は2.11までのEitherの仕様であり、不要ではないかと考えました。