### PR TITLE
コンパニオンオブジェクトの説明で :paste コマンドを使った場合の例もメソッドに変更

### DIFF
--- a/src/object.md
+++ b/src/object.md
@@ -109,8 +109,10 @@ scala> :paste
 class Person(name: String, age: Int, private val weight: Int)
 
 object Person {
-  val taro = new Person("Taro", 20, 70)
-  println(taro.weight)
+  def printWeight(): Unit = {
+    val taro = new Person("Taro", 20, 70)
+    println(taro.weight)
+  }
 }
 
 // Exiting paste mode, now interpreting.


### PR DESCRIPTION
#205 において、[コンパニオンオブジェクトの説明](https://dwango.github.io/scala_text/object.html#コンパニオンオブジェクト) の object中の処理がメソッドに変更されましたが、その下にある `:paste` コマンドを使った例の方がそのままになっている気がします。