### PR TITLE
FutureとPromiseに関するサンプルコードのバグを修正

### DIFF
--- a/src/future-and-promise.md
+++ b/src/future-and-promise.md
@@ -348,10 +348,13 @@ object CallbackFuture extends App {
   val iFuture = futureSomething.doSomething()
   val jFuture = futureSomething.doSomething()
 
-  for {
+  val iplusj = for {
     i <- iFuture
     j <- jFuture
-  } yield println(s"$i, $j")
+  } yield i + j
+
+  val result = Await.result(iplusj, Duration.Inf)
+  println(result)
 }
 ```
 


### PR DESCRIPTION
* `for`の`yield`で直接`print`するのではなく、`Await.result`で結果を取得して`println`するようにした。