### PR TITLE
example_projectsのsbt versionを0.13.16に

### DIFF
--- a/src/example_projects/trait-example/project/build.properties
+++ b/src/example_projects/trait-example/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/src/example_projects/trait-refactored-example/project/build.properties
+++ b/src/example_projects/trait-refactored-example/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16


### PR DESCRIPTION
https://github.com/dwango/scala_text/pull/292 に書いたように、example_projectsのほうは、もうしばらく0.13にしておく？が、そうだとしても微妙にsbtのversion古いのに気がついたので、0.13系の最新の0.13.16にあげておく