### PR TITLE
Scala 2.12 に依存したsbt 1.0 が出たので、再びsbtのコードをtutでコンパイルする

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,7 @@ tutSourceDirectory := srcDir
 tutTargetDirectory := compiledSrcDir
 
 libraryDependencies ++= Seq(
-  // sbt_2.12はしばらく出ない可能性が高いので下記PR内容をリバートしている
-  // https://github.com/dwango/scala_text/pull/118
-  // "org.scala-sbt" % "sbt" % "1.0.0-M4",
+  "org.scala-sbt" % "sbt" % sbtVersion.value,
   "org.mockito" % "mockito-core" % "2.7.22",
   "org.scalacheck" %% "scalacheck" % "1.13.5",
   "org.scalatest" %% "scalatest" % "3.0.3" // tutで使うので、テストライブラリだが、わざとcompileスコープ

--- a/src/sbt-compile-execute.md
+++ b/src/sbt-compile-execute.md
@@ -1,5 +1,9 @@
 # sbtでプログラムをコンパイル・実行する
 
+```tut:invisible
+import sbt._, Keys._
+```
+
 前節まででは、REPLを使ってScalaのプログラムを気軽に実行してみました。この節ではScalaのプログラムをsbtでコンパイルして実行する方法を学びましょう。
 まずはREPLの時と同様にHello, World!を表示するプログラムを作ってみましょう。その前に、REPLを抜けましょう。REPLを抜けるには、REPLから以下のように
 入力します[^repl-quit]。
@@ -34,7 +38,7 @@ sandbox
 
 今回の_build.sbt_にはScalaのバージョンと一緒に`scalac`の警告オプションも有効にしてみましょう。
 
-```scala
+```tut:silent
 // build.sbt
 scalaVersion := "2.12.2"
 

--- a/src/sbt-install.md
+++ b/src/sbt-install.md
@@ -1,5 +1,9 @@
 # sbtをインストールする
 
+```tut:invisible
+import sbt._, Keys._
+```
+
 現実のScalaアプリケーションでは、Scalaプログラムを手動でコンパイル[^scalac]することは非常に稀で、
 標準的なビルドツールである[sbt（Simple Build Tool）](http://www.scala-sbt.org/release/tutorial/ja/Setup.html)というツールを用いることになり
 ます。ここでは、sbtのインストールについて説明します。
@@ -75,7 +79,7 @@ scala> :quit
 になってしまうので、こちらが指定したバージョンのScalaでREPLを起動したい場合は、同じディレクトリに
 _build.sbt_というファイルを作成し、
 
-```scala
+```tut:silent
 scalaVersion := "2.12.2"
 ```
 

--- a/src/test.md
+++ b/src/test.md
@@ -124,7 +124,11 @@ BDDでは、テスト内にそのプログラムに与えられた機能的な�
 
 `build.sbt`を用意して、以下を記述しておきます。
 
-```scala
+```tut:invisible
+import sbt._, Keys._
+```
+
+```tut:silent
 name := "scalatest_study"
 
 version := "1.0"
@@ -394,7 +398,7 @@ BDDでテストを書くことによってテストによってどのような�
 ここでは、ドワンゴ社内で利用率の高いMockitoを利用してみましょう。
 `build.sbt`に以下を追記することで利用可能になります。
 
-```scala
+```tut:silent
 libraryDependencies += "org.mockito" % "mockito-core" % "2.7.22" % "test"
 ```
 
@@ -440,7 +444,7 @@ class CalcSpec extends FlatSpec with DiagrammedAssertions with Timeouts with Moc
 
 `project/plugins.sbt` に以下のコードを記述します。
 
-```scala
+```tut:silent
 resolvers += Classpaths.sbtPluginReleases
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
@@ -474,7 +478,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 使い方は、`project/plugins.sbt` に以下のコードを記述します。
 
-```scala
+```tut:silent
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 ```
 


### PR DESCRIPTION
つまり https://github.com/dwango/scala_text/commit/6067c05053612993558f7a6fdb543394fa6f1c21
を、さらにまたrevertし、revertによるコンフリクト解消