### PR TITLE
Simple Build Toolという表現を削除

### DIFF
--- a/src/sbt-install.md
+++ b/src/sbt-install.md
@@ -5,7 +5,7 @@ import sbt._, Keys._
 ```
 
 現実のScalaアプリケーションでは、Scalaプログラムを手動でコンパイル[^scalac]することは非常に稀で、
-標準的なビルドツールである[sbt（Simple Build Tool）](http://www.scala-sbt.org/release/tutorial/ja/Setup.html)というツールを用いることになり
+標準的なビルドツールである[sbt](http://www.scala-sbt.org/release/tutorial/ja/Setup.html)というツールを用いることになり
 ます。ここでは、sbtのインストールについて説明します。
 
 ## Mac OSの場合


### PR DESCRIPTION
[simple build toolで検索](https://github.com/sbt/sbt/search?utf8=%E2%9C%93&q=simple+build+tool&type=)してヒットしなかったのですが、まだSimple Build Toolと言われているんでしょうか。