### PR TITLE
nodejsを最新安定版にする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 - oraclejdk8
 before_install:
 - export CXX='g++-4.8'
-- nvm install 4.4.0 && nvm use 4.4.0 && npm install
+- nvm install 8.9.1 && nvm use 8.9.1 && npm install
 - npm install svgexport -g
 cache:
   directories:


### PR DESCRIPTION
プレビュー表示されるはずのURL

http://dwango.github.io/scala_text_previews/nodejs-latest/