### PR TITLE
デプロイ(gh-pagesへのpushなど)が失敗した場合にエラー箇所をわかりやすくする

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 echo -e "Host github.com\n\tStrictHostKeyChecking no\nIdentityFile ~/.ssh/deploy.key\n" >> ~/.ssh/config &&
 openssl aes-256-cbc -k "$SERVER_KEY" -in travis_deploy_key.enc -d -a -out deploy.key &&


### PR DESCRIPTION
https://github.com/dwango/scala_text/commits/gh-pages

2017-11-29を最後にpushに失敗している。
なんで失敗してるのか、多少原因の検討はついているが、より正確に原因をわかりやすくするために、まずコマンドがどこまで実行されたか？を、全部わかるようにする

```
error: Your local changes to the following files would be overwritten by checkout:
    package.json
Please commit your changes or stash them before you switch branches.
Aborting
```