### PR TITLE
gh-pagesへのpushに失敗する問題を解決

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -11,6 +11,9 @@ mv gitbook/_book ../ &&
 mv gitbook/scala_text.epub ../_book/scala_text.epub &&
 git fetch origin gh-pages:gh-pages &&
 git clean -fdx &&
+git status &&
+git reset . &&
+git checkout . &&
 git checkout gh-pages &&
 rm -rf ./* &&
 echo -e "*class\ntarget" > .gitignore &&


### PR DESCRIPTION
https://github.com/dwango/scala_text/issues/396 に現象(package-lock.jsonが変更されてる？)を書いたが、これがベストな解決方法なのか？は、議論の余地あるかもしれないが、travis-ciのログ見て、直りそうなら一旦これをmerge？