### PR TITLE
gitに登録されているファイルに差分があったらビルドを失敗にする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
   exec(sys.stdin.read()); main('~/calibre-bin', True)" >/dev/null &&
   export PATH="~/calibre-bin/calibre/:/home/travis/calibre-bin/calibre/:$PATH" &&
   sbt "textBuildEpub"
+- git diff --exit-code
 after_success:
 - "./deploy.sh"
 after_script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3938,6 +3938,7 @@
         "config-chain": "1.1.11",
         "debuglog": "1.0.1",
         "detect-indent": "5.0.0",
+        "dezalgo": "1.0.3",
         "editor": "1.0.0",
         "fs-vacuum": "1.2.10",
         "fs-write-stream-atomic": "1.0.10",
@@ -4218,6 +4219,16 @@
           "version": "5.0.0",
           "bundled": true,
           "dev": true
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+          "dev": true,
+          "requires": {
+            "asap": "2.0.6",
+            "wrappy": "1.0.2"
+          }
         },
         "editor": {
           "version": "1.0.0",
@@ -5582,6 +5593,7 @@
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
             "once": "1.4.0",
             "read-package-json": "2.0.9",
             "readdir-scoped-modules": "1.0.2"
@@ -5637,6 +5649,7 @@
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
+            "dezalgo": "1.0.3",
             "graceful-fs": "4.1.11",
             "once": "1.4.0"
           }


### PR DESCRIPTION
JavaScript詳しくないので package-lock.json がどうなっているべきか、完全にはよくわかってないが、おそらくgitbook生成のコマンド実行後に  package-lock.json が書き換わってしまうらしい？

- https://github.com/dwango/scala_text/issues/396
- https://github.com/dwango/scala_text/issues/377

gitbookのコマンド実行しても書き換わらない状態のものを登録しておく(それをチェックする)なら、こういうコマンドを実行してチェックしておくべき？

(ちなみにgitbookのコマンドはsbt経由で実行してる) 