### PR TITLE
Fix: do while文 -> do while式

### DIFF
--- a/src/control-syntax.md
+++ b/src/control-syntax.md
@@ -139,7 +139,7 @@ while(i <= 10) {
 }
 ```
 
-Javaで`while`文を使った場合と同様です。`do while`文もありますが、ほぼJavaと同じなので説明は省略します。なお、`break`文や`continue`文に相当するものはありません。
+Javaで`while`文を使った場合と同様です。`do while`式もありますが、ほぼJavaと同じなので説明は省略します。なお、`break`文や`continue`文に相当するものはありません。
 
 ### 練習問題 {#control_syntax_ex2}
 


### PR DESCRIPTION
> `do while`文もありますが、ほぼJavaと同じなので説明は省略します。

上記の表現では、「**Scalaには** `do while`文もあります」と解釈できます。
 `do while`はUnit型の値を返す以上、 `do while`**式**という書き方が適していると思います。