### PR TITLE
Scala APIへのリンクを修正

### DIFF
--- a/src/collection.md
+++ b/src/collection.md
@@ -267,7 +267,7 @@ joinByComma(1, 10)
 
 ### foldLeft：左からの畳み込み
 
-`foldLeft`メソッドは`List`にとって非常に基本的なメソッドです。他の様々なメソッドを`foldLeft`を使って実装することができます。`foldLeft`の宣言を[ScalaのAPIドキュメント](https://www.scala-lang.org/api/current/index.html#scala.collection.immutable.List)から引用すると、
+`foldLeft`メソッドは`List`にとって非常に基本的なメソッドです。他の様々なメソッドを`foldLeft`を使って実装することができます。`foldLeft`の宣言を[ScalaのAPIドキュメント](https://www.scala-lang.org/api/current/scala/collection/immutable/List.html)から引用すると、
 
 ```scala
 def foldLeft[B](z: B)(f: (B, A) ⇒ B): B
@@ -341,7 +341,7 @@ Testing.test(arbitrary[List[Int]]){ list =>
 ### foldRight：右からの畳み込み
 
 `foldLeft`が`List`の左からの畳み込みだったのに対して、`foldRight`は右からの畳込みです。`foldRight`の宣言を
-[ScalaのAPIドキュメントから](https://www.scala-lang.org/api/current/index.html#scala.collection.immutable.List)参照すると、
+[ScalaのAPIドキュメントから](https://www.scala-lang.org/api/current/scala/collection/immutable/List.html)参照すると、
 
 ```scala
 def foldRight[B](z: B)(op: (A, B) ⇒ B): B
@@ -408,7 +408,7 @@ mul(List(1, 2, 3, 4, 5))
 #### 練習問題
 
 `mkString`を実装してみましょう。`mkString`そのものを使ってはいけませんが、`foldLeft`や`foldRight`などの`List`に定義されている
-他のメソッドは自由に使って構いません。[ListのAPIリファレンス](https://www.scala-lang.org/api/current/index.html#scala.collection.immutable.List)
+他のメソッドは自由に使って構いません。[ListのAPIリファレンス](https://www.scala-lang.org/api/current/scala/collection/immutable/List.html)
 を読めば必要なメソッドが載っています。実装する`mkString`の宣言は
 
 ```tut:silent
@@ -534,7 +534,7 @@ def count[T](list: List[T])(f: T => Boolean): Int  = {
 ### flatMap：`List`をたいらにする
 
 `flatMap`は一見少し変わったメソッドですが、後々重要になってくるメソッドなので説明しておきます。flatMapの
-宣言は[ScalaのAPIドキュメントから](https://www.scala-lang.org/api/current/index.html#scala.collection.immutable.List)参照すると、
+宣言は[ScalaのAPIドキュメントから](https://www.scala-lang.org/api/current/scala/collection/immutable/List.html)参照すると、
 
 ```scala
 final def flatMap[B](f: (A) ⇒ GenTraversableOnce[B]): List[B]

--- a/src/future-and-promise.md
+++ b/src/future-and-promise.md
@@ -28,7 +28,7 @@ JVM系の言語では、マルチスレッドで並行処理を使った非同�
 
 ## Futureとは
 
-[Future](https://www.scala-lang.org/api/current/index.html#scala.concurrent.Future)とは、
+[Future](https://www.scala-lang.org/api/current/scala/concurrent/Future.html)とは、
 非同期に処理される結果が入ったOption型のようなものです。
 mapやflatMapやfilter、for式の適用といったようなOptionやListでも利用できる性質を持っています。
 
@@ -274,14 +274,14 @@ object CompositeFutureSample extends App {
 `Failure: second waitMilliSec is 133`といったものとなります。
 
 なおFutureにはfilterの他、様々な並列実行に対するメソッドが存在しますので、
-[APIドキュメント](https://www.scala-lang.org/api/current/index.html#scala.concurrent.Future)を見てみてください。
+[APIドキュメント](https://www.scala-lang.org/api/current/scala/concurrent/Future.html)を見てみてください。
 また複数のFuture生成や[並列実行に関してのまとめられた日本語の記事](https://qiita.com/mtoyoshi/items/297f6acdfe610440c719)もありますので、
 複雑な操作を試してみたい際にはぜひ参考にしてみてください。
 
 
 ## Promiseとは
 
-[Promise](https://www.scala-lang.org/api/current/index.html#scala.concurrent.Promise)とは、
+[Promise](https://www.scala-lang.org/api/current/scala/concurrent/Promise.html)とは、
 
 成功あるいは失敗を表す値を設定することによってFutureに変換することのできるクラスです。 実際にサンプルコードを示します。
 

--- a/src/implicit.md
+++ b/src/implicit.md
@@ -322,7 +322,7 @@ println(sum(List(Point(1, 2), Point(3, 4), Point(5, 6)))) // Point(9, 12)
 ### 練習問題 {#implicit_ex5}
 
 `List[Int]` と `List[Double]` のsumを行うために、標準ライブラリでは何という型クラス（1つ）と型クラスのインスタンス
-（2つ）を定義しているかを、[Scala標準ライブラリ](https://www.scala-lang.org/api/current/index.html#package)から
+（2つ）を定義しているかを、[Scala標準ライブラリ](https://www.scala-lang.org/api/current/index.html)から
 探して挙げなさい。
 
 <!-- begin answer id="answer_ex3" style="display:none" -->

--- a/src/java-interop.md
+++ b/src/java-interop.md
@@ -264,11 +264,11 @@ val scalaList = list.asScala
 ```
 
 BufferはScalaの変更可能なリストのスーパークラスですが、ともあれ、asScalaメソッドによってJavaのコレクションをScalaのそれに変換することができている
-ことがわかります。そのほかのコレクションについても同様に変換できますが、詳しくは[APIドキュメント](https://www.scala-lang.org/api/current/index.html#scala.collection.JavaConverters$)を参照してください。
+ことがわかります。そのほかのコレクションについても同様に変換できますが、詳しくは[APIドキュメント](https://www.scala-lang.org/api/current/scala/collection/JavaConverters$.html)を参照してください。
 
 ##### 練習問題
 
-[`scala.collection.mutable.ArrayBuffer`](https://www.scala-lang.org/api/current/index.html#scala.collection.mutable.ArrayBuffer)型の値を生成してから、JavaConvertersを使って[java.util.List](https://docs.oracle.com/javase/jp/8/docs/api/java/util/List.html)型に変換してみましょう。なお、`ArrayBuffer`には1つ以上の要素を入れておくこととします。
+[`scala.collection.mutable.ArrayBuffer`](https://www.scala-lang.org/api/current/scala/collection/mutable/ArrayBuffer.html)型の値を生成してから、JavaConvertersを使って[java.util.List](https://docs.oracle.com/javase/jp/8/docs/api/java/util/List.html)型に変換してみましょう。なお、`ArrayBuffer`には1つ以上の要素を入れておくこととします。
 
 <!-- begin answer id="answer_ex5" style="display:none" -->
 


### PR DESCRIPTION
以前とURLの形式が変わったため、rootパッケージに飛ばされてしまっていた
Fix #422