### PR TITLE
http status 404になるurlを差し替え

### DIFF
--- a/src/trait.md
+++ b/src/trait.md
@@ -405,4 +405,4 @@ class C extends {
 この事前定義の機能は実際のコードではあまり見ることはないかもしれません。
 
 
-[^trait-param-dotty]: 次世代Scalaコンパイラである[Dotty](http://dotty.epfl.ch/)では、[トレイトがパラメータを取る](http://dotty.epfl.ch/docs/reference/trait-parameters.html)ことができます。
+[^trait-param-dotty]: 次世代Scalaコンパイラである[Dotty](http://dotty.epfl.ch/)では、[トレイトがパラメータを取る](https://docs.scala-lang.org/sips/trait-parameters.html)ことができます。


### PR DESCRIPTION
一時的なものなのか、恒久的なものなのか？はわからないがエラーになるので。
dottyのトップページから
https://dotty.epfl.ch/
このSIPのページにリンクされていたので、これに差し替え