### PR TITLE
gitのcommitに使うuser.email, user.nameを変更

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,8 +5,8 @@ echo -e "Host github.com\n\tStrictHostKeyChecking no\nIdentityFile ~/.ssh/deploy
 openssl aes-256-cbc -k "$SERVER_KEY" -in travis_deploy_key.enc -d -a -out deploy.key &&
 cp deploy.key ~/.ssh/ &&
 chmod 600 ~/.ssh/deploy.key &&
-git config --global user.email "6b656e6a69@gmail.com" &&
-git config --global user.name "xuwei-k" &&
+git config --global user.email "mizukota@gmail.com" &&
+git config --global user.name "Kota Mizushima" &&
 mv gitbook/_book ../ &&
 mv gitbook/scala_text.epub ../_book/scala_text.epub &&
 git fetch origin gh-pages:gh-pages &&


### PR DESCRIPTION
dwango退職するので。
https://xuwei-k.hatenablog.com/entry/2019/01/17/232917
別にここを変えないままでも自動でgithub pagesにpushする動作に特に支障はないが、一応変えておく。

pdfのほう
https://github.com/dwango/scala_text_pdf/pull/9
と同様に、ひとまずkmizuさんにしておく。

ここで実在のアカウントに紐付いたemailにすると、良くも悪くもcontributionにカウントされる(草生える)気がするので、本来botアカウント的なものにしたほうがいいかもしれないが、規約上githubは無料枠で勝手にbot作るとbanされたりするので(されたことがある)。

もしくは、存在しなそうな適当なemailにする、gmailのalias使う、などの手はある？がどうするか 🤔 